### PR TITLE
Exit with code 1 on error

### DIFF
--- a/src/cp-cli.ts
+++ b/src/cp-cli.ts
@@ -23,5 +23,6 @@ fse.copy(source, target, options).catch((error: Error) => {
   if (error) {
     // tslint:disable-next-line
     console.error(error);
+    process.exit(1);
   }
 });


### PR DESCRIPTION
If this is not present, it breaks cli chaining (like `cp-cli foo bar/ && cat bar/foo`)